### PR TITLE
Fix problem 23 chapter 1 solution

### DIFF
--- a/src/chapters/1/sections/naive_definition_of_probability/problems/23.tex
+++ b/src/chapters/1/sections/naive_definition_of_probability/problems/23.tex
@@ -1,18 +1,14 @@
-Case 1: All three go to the same floor.
-
-They can go to floors $2$ to $10$ for a total of $9$ choices.
-
-Case 2: Two of them go to the same floor.
-
-There are $9 \choose 2$ possibilities in this case.
-
-Case 3: They all go to different floors.
-
-There are $9 \choose 3$ possibilities in this case.
-
 We are interested in the case of $3$ consecutive floors. There are $7$ equally 
 likely possibilities $$(2, 3, 4), (3, 4, 5), (4, 5, 6), (5, 6, 7), 
 (6, 7, 8), (7, 8, 9), (8, 9, 10).$$
 
-Hence, the probability that the buttons for $3$ consecutive floors are 
-pressed is $$\frac{7}{9 + {9 \choose 2} + {9 \choose 3}}$$
+For each of this possibilities, there are $3$ ways for $1$ person to choose 
+button, $2$ for second and $1$ for third ($3!$ in total by multiplication rule).
+
+So number of favorable combinations is $$7 * 3!$$
+
+Generally each person have $9$ floors to choose from so for $3$ people there are 
+$9^3$ combinations by multiplication rule.
+
+Hence, the probability that the buttons for $3$ consecutive floors are pressed
+is $$\frac{7 * 3!}{9^3}$$


### PR DESCRIPTION
In previous solution possible cases were counted as unordered.
In such approach naive definition of probability can't be applied
because not all combinations are equally likely.
For example {2, 2, 2} is less likely than {2, 3, 3} because it have
only one (2, 2, 2) permutation and {2, 3, 3} have 3: (2, 3, 3),
(3, 2, 3), (3, 3, 2).