### PR TITLE
Fix problem 59 chapter 1 solution

### DIFF
--- a/src/chapters/1/sections/mixed_practice/problems/59.tex
+++ b/src/chapters/1/sections/mixed_practice/problems/59.tex
@@ -7,5 +7,9 @@
 Each of 15 bars can be given to any of 10 children, so by orderd sampling with replcement
 formula we have $10^{15}$ combinations
 
-\item $10^{15} - \sum_{i=1}^{10}\left(-1\right)^{i+1}\binom{10}{i}\left(10-i\right)^{15}$
+\item
+To count amount of suitable combinations, we can subtract amount of combination, where at
+least one child doesn't get any bars (is example of inclusion-exclusion usage case) from
+total amount of combinations.\\
+$10^{15} - \sum_{i=1}^{9}\left(-1\right)^{i+1}\binom{10}{i}\left(10-i\right)^{15}$
 \end{enumerate}

--- a/src/chapters/1/sections/mixed_practice/problems/59.tex
+++ b/src/chapters/1/sections/mixed_practice/problems/59.tex
@@ -3,7 +3,9 @@
 
 \item $\binom{5+9}{9}$
 
-\item $\binom{15+9}{9}15!$
+\item 
+Each of 15 bars can be given to any of 10 children, so by orderd sampling with replcement
+formula we have $10^{15}$ combinations
 
 \item $10^{15} - \sum_{i=1}^{10}\left(-1\right)^{i+1}\binom{10}{i}\left(10-i\right)^{15}$
 \end{enumerate}


### PR DESCRIPTION
c case fix explanation: 
Previous provided solution for case c overcounts.
For example on 2 childs and 4 bars. Let a,b,c,d be bars.
If we use provided solution of multiplying amount of ways to divide
interchangeable bars between children and multiplying by 15! possible
permutations
(a, b), (c, d) and (b, a), (c, d)
divisions of bars will be counted as different, despite permutation of
a and b don't change which bars go to which child.

New solution just counts using ordered sampling with replacment.
Because each of 15 bars can be given to any of 10 children
we have 10^15 combinations.


d case fix explanation:
Inclusion-exclusion sum should not include case, where i=10 because in
such case amount of children who will not get at least one bar is 10,
meaning no one will get anything, which is not valid.