### PR TITLE
Fix undercounting (Chapter 1 Problem 32)

### DIFF
--- a/src/chapters/1/sections/naive_definition_of_probability/problems/32.tex
+++ b/src/chapters/1/sections/naive_definition_of_probability/problems/32.tex
@@ -22,7 +22,7 @@ Case 3: $j=2$
 One of the guesses is red the other is black. Like before, there are two 
 choices for the red and two choices for the black cards. This undercounts the 
 possibilities by a factor of 2, since we can switch the places of the red and 
-the black cards. Hence, $$P(j=2) = \frac{2}{6} = \frac{1}{3}$$
+the black cards. Hence, $$P(j=2) = \frac{2}{6} + \frac{2}{6} = \frac{2}{3}$$
 
 Notice that getting both right, none right and one right are all the possible 
 outcomes. Hence, $$P(j=1) = P(j=3) = 0$$


### PR DESCRIPTION
Notice that currently the probabilities do not sum up to 1 which is a sign of the undercounting - 1/6 + 2/6 + 1/6 = 4/6

After we guess the first red card we have two situations - either we were correct and we have 2 black and 1 red cards left to guess from. In this case the probability to pick a black card is 2/3. Thus (1/2) * (2/3) = 2/6. By symmetry if we picked a black card first we have 2/3 chance to pick a red card next. Thus 2/6 + 2/6 total probability.