### PR TITLE
Update 32.tex

### DIFF
--- a/src/chapters/3/sections/named_distributions/problems/32.tex
+++ b/src/chapters/3/sections/named_distributions/problems/32.tex
@@ -7,8 +7,8 @@ for $0 \leq k \leq s$.
 \item 
 \begin{verbatim}
 > x = 75
-> y_phyper <- phyper(x, m = 75, n = 25, k = 10)
-> y_phyper
-[1] 1
+> y_interval <- sum(dhyper(7:10, x, 100-x, 10))
+> y_interval
+[1] 0.7853844
 \end{verbatim}
 \end{enumerate}


### PR DESCRIPTION
The previous solution computed

phyper(75, 75, 25, 10)

which computes the probability that the number of terms both studied (75) and on the exam (10) is less than or equal to 75, which must be 1 since there are only 10 terms on the exam to begin with. This is an incorrect interpretation of the problem - instead, we want to compute the probability that the number of terms both studied and on the exam is between 7 and 10 inclusive, so we must instead compute

sum(dhyper(7:10, 75, 25, 10))