### PR TITLE
Update 53.tex

### DIFF
--- a/src/chapters/4/sections/indicator_r.v.s/problems/53.tex
+++ b/src/chapters/4/sections/indicator_r.v.s/problems/53.tex
@@ -5,8 +5,12 @@ $1 \leq j \leq 3$. Then, the expected number of such pairs is $\text{E}(X) =
 
 $\text{E}(X^{2}) = \text{E}((\sum_{j=1}^{3}I_{j})^{2}) = \text{E}((I_{1} + I_
 {2})^{2} + 2(I_{1}+I_{2})I_{3} + I_{3}^{2}) = \text{E}(I_{1}^{2} + 2I_{1}I_{2}
-+ I_{2}^{2} + 2I_{1}I{3} + 2I_{2}I{3} + I_{3}^{2})$. Note that $I_{j}^{2} = I_
-{j}$. Thus, $\text{E}(X^{2}) = (p^{2} + 2p^{3} + p^{2} + 2p^{3} + 2p^{3} + p^
-{2}) = 6p^{3} + 3p^{2}$.
++ I_{2}^{2} + 2I_{1}I{3} + 2I_{2}I{3} + I_{3}^{2})$. 
 
-Thus, $$\text{Var}(X)= 6p^{3} + 3p^{2} - 9p^{4}$$
+Note that $I_{j}^{2} = I_
+{j}$. 
+
+Note that $E(I_{1}I_{2})=E(I_{2}I_{3})=p^{3}$ as these require 3 consecutive heads to equal 1, but $E(I_{1}I_{3}) = p^{4}$ as this requires 4 consecutive heads to equal 1. Thus, $\text{E}(X^{2}) = (p^{2} + 2p^{3} + p^{2} + 2p^{4} + 2p^{3} + p^
+{2}) = 4p^{3} + 3p^{2} + 2p^{4}$.
+
+Thus, $$\text{Var}(X)= 4p^{3} + 3p^{2} - 7p^{4}$$


### PR DESCRIPTION
Unlike E(I1I2) and E(I2I3), E(I1I3) is not p^3 but rather p^4. I have changed the solution to reflect this.