### PR TITLE
Update 91.tex

### DIFF
--- a/src/chapters/4/sections/mixed_practice/problems/91.tex
+++ b/src/chapters/4/sections/mixed_practice/problems/91.tex
@@ -4,9 +4,5 @@ positions in the ordered list.
 $$\text{E}(R) = \sum_{j=1}^{m}\text{E}(R_{j}) = \sum_{j=1}^{m}\frac{(m+n)
 (m+n+1)}{2}\frac{1}{m+n} = m\frac{m+n+1}{2}.$$
 
-\item $R_{j} = (\sum_{k=1}^{m+n-1}I_{k} + 1)$ where $I_{k}$ is the indicator
-random
-variable for $X_{j}$ being larger than the sample at index $k$ in the ordered
-list. Then $\text{E}(R_{j}) = (m+n-1)p + 1$.Thus, $\text{E}(R) = m((m+n-1)p +
-1)$.
+\item $R_{j} = (\sum_{k=1}^{n}I_{Y_{k}} + \sum_{k \neq j}I_{X_{k}} + 1)$ where $I_{Y_{k}}$ are the indicator random variables for $X_{j}$ being larger than $Y_{k}$ and $I_{X_{k}}$ are the indicator random variables for $X_{j}$ being larger than $X_{k}$. Note that $E(I_{Y_{k}}) = p$ for all k since the Ys are iid, and $E(I_{X_{k}}) = 1/2$ - $X_{j}$ and $X_{k}$ are iid and never equal, so they are equally likely to be bigger or smaller than the other. Then $\text{E}(R_{j}) = np + (m-1)/2 + 1$.Thus, $\text{E}(R) = m(np + (m-1)/2 + 1)$.
 \end{enumerate}


### PR DESCRIPTION
Because the Xs and Ys do not have the same distribution, in part b, it is not correct to assert that the indicator rvs for X_j being bigger than any other Y or X all have expected value p - only the indicator rvs for being bigger than Y have expectation p. The indicator rvs for X_j being bigger than another X have expectation 1/2 since they are iid. The solution has been updated to reflect this.