### PR TITLE
fix solution to prob. 33 in ch. 2

### DIFF
--- a/src/chapters/2/sections/independence_and_conditional_independence/problems/33.tex
+++ b/src/chapters/2/sections/independence_and_conditional_independence/problems/33.tex
@@ -11,7 +11,7 @@
           Hence, $|S| = 4^{100}$.
           The number of elements in the set $X$ of outcomes corresponding to $A \subseteq B$ can be counted as
           $$|X| = \sum_{i=0}^{100} \binom{100}{i}2^i = 3^{100}.$$
-          The binomial coefficient accounts for the number of $i$-element subsets $B$ of $C$ and $2^i$ is the number of $i$-element subsets $A$ of $B$.
+          The binomial coefficient accounts for the number of $i$-element subsets $B$ of $C$ and $2^i$ is the number of all subsets $A$ of $B$.
           This gives $P(A \subseteq B) = |X| / |S| = (3/4)^{100}.$
 
     \item Let $p$ be a randomly selected person from $C$ sampled without

--- a/src/chapters/2/sections/independence_and_conditional_independence/problems/33.tex
+++ b/src/chapters/2/sections/independence_and_conditional_independence/problems/33.tex
@@ -1,15 +1,25 @@
 \begin{enumerate}[label=(\alph*)]
 
-\item $\frac{1}{2^{|C|}}$
+    \item $\frac{1}{2^{|C|}}$
 
-\item $\left(\frac{1}{2}\right)^{|A|}$
+    \item For each element of $C$ we have four options for whether this element is in $A$ and/or $B$ and each option has equal probability of occurring.
+          An element $x \in C$ is in $A \subseteq B$ if and only if ($x \in B \text{ and } x \in A$) or ($x \in B \text{ and } x \notin A$) or ($x \notin B \text{ and } \notin A$), i.e., 3 times out of 4.
+          Thus, the probability that $x \in A \subseteq B$ is $3/4$ and $P(A \subseteq B) = (3/4)^{100}$.
 
-\item Let $p$ be a randomly selected person from $C$ sampled without
-replacement.
+          Another way to see this is by using the naive definition of probability.
+          The sample space consists of 100 binary pairs where 1 in the 1st slot of the $i$-th pair indicates that the $i$-th element of $C$ is in $A$ and 1 in the 2nd slot indicates that the element is in $B$.
+          Hence, $|S| = 4^{100}$.
+          The number of elements in the set $X$ of outcomes corresponding to $A \subseteq B$ can be counted as
+          $$|X| = \sum_{i=0}^{100} \binom{100}{i}2^i = 3^{100}.$$
+          The binomial coefficient accounts for the number of $i$-element subsets $B$ of $C$ and $2^i$ is the number of $i$-element subsets $A$ of $B$.
+          This gives $P(A \subseteq B) = |X| / |S| = (3/4)^{100}.$
 
-$P(p \in A \cup p \in B) = \frac{1}{2} + \frac{1}{2} - \frac{1}{4} = \frac{3}
-{4}$.
+    \item Let $p$ be a randomly selected person from $C$ sampled without
+          replacement.
 
-$P(A \cup B = C) = (P(p \in A \cup p \in B))^{|C|} = \left(\frac{3}{4}\right)^
-{|C|}.$
+          $P(p \in A \cup p \in B) = \frac{1}{2} + \frac{1}{2} - \frac{1}{4} = \frac{3}
+              {4}$.
+
+          $P(A \cup B = C) = (P(p \in A \cup p \in B))^{|C|} = \left(\frac{3}{4}\right)^
+              {|C|}.$
 \end{enumerate}


### PR DESCRIPTION
The solution to part (b) is incorrect as posted.
The proposed solution can be verified through simulation:
```r
results <- replicate(trials, {
  A <- sample(c(0,1), set_size, replace=TRUE)
  B <- sample(c(0,1), set_size, replace=TRUE)
  all((A & B) == A)
})

print(sum(results) / trials) # should be close to (3/4)^set_size
```